### PR TITLE
Implemented readonly VIEWS for Discussion module

### DIFF
--- a/src/it/java/com/hexlindia/drool/discussion/DiscussionReplyIT.java
+++ b/src/it/java/com/hexlindia/drool/discussion/DiscussionReplyIT.java
@@ -116,7 +116,7 @@ public class DiscussionReplyIT {
         ResponseEntity<DiscussionReplyTo> responseEntity = restTemplate.exchange(getFindByIdUri() + "/1", HttpMethod.GET, httpEntity, DiscussionReplyTo.class);
         DiscussionReplyTo discussionReplyTo = responseEntity.getBody();
         assertEquals(1L, discussionReplyTo.getId());
-        assertEquals(4L, discussionReplyTo.getUserId());
+        assertEquals(3L, discussionReplyTo.getUserId());
         assertEquals(2, discussionReplyTo.getLikes());
     }
 

--- a/src/it/java/com/hexlindia/drool/discussion/DiscussionTopicIT.java
+++ b/src/it/java/com/hexlindia/drool/discussion/DiscussionTopicIT.java
@@ -113,10 +113,10 @@ public class DiscussionTopicIT {
         ResponseEntity<DiscussionTopicTo> responseEntity = restTemplate.exchange(getFindByIdUri() + "/1", HttpMethod.GET, httpEntity, DiscussionTopicTo.class);
         DiscussionTopicTo discussionTopicTo = responseEntity.getBody();
         assertEquals(1L, discussionTopicTo.getId());
-        assertEquals(5L, discussionTopicTo.getUserId());
+        assertEquals(1L, discussionTopicTo.getUserId());
         assertEquals(15, discussionTopicTo.getViews());
         assertEquals(12, discussionTopicTo.getLikes());
-        assertEquals(1, discussionTopicTo.getReplies());
+        assertEquals(2, discussionTopicTo.getReplies());
     }
 
     @Test

--- a/src/it/java/com/hexlindia/drool/discussion/DiscussionViewIT.java
+++ b/src/it/java/com/hexlindia/drool/discussion/DiscussionViewIT.java
@@ -1,0 +1,84 @@
+package com.hexlindia.drool.discussion;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hexlindia.drool.discussion.view.DiscussionPageView;
+import com.hexlindia.drool.discussion.view.DiscussionReplyCardView;
+import com.hexlindia.drool.discussion.view.DiscussionTopicCardView;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class DiscussionViewIT {
+
+    @Value("${rest.uri.version}")
+    String restUriVersion;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    /*
+    Find Discussion topic card by Id
+     */
+    @Test
+    void testFindDiscussionTopicCardById() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> httpEntity = new HttpEntity<>(null, headers);
+        ResponseEntity<DiscussionTopicCardView> responseEntity = restTemplate.exchange(getfindDiscussionTopicCardViewByIdUri() + "/1", HttpMethod.GET, httpEntity, DiscussionTopicCardView.class);
+        DiscussionTopicCardView discussionTopicCardView = responseEntity.getBody();
+        assertEquals(1L, discussionTopicCardView.getDiscussionTopicView().getTopicId());
+        assertEquals("Are Loreal lip colors better than Lakme or is it the other way around", discussionTopicCardView.getDiscussionTopicView().getTopic());
+        assertEquals(1L, discussionTopicCardView.getDiscussionTopicView().getUserId());
+        assertNotNull(discussionTopicCardView.getDiscussionTopicView().getDatePosted());
+        assertNotNull(discussionTopicCardView.getDiscussionTopicView().getDateLastActive());
+        assertEquals(15, discussionTopicCardView.getDiscussionTopicView().getViews());
+        assertEquals(12, discussionTopicCardView.getDiscussionTopicView().getLikes());
+        assertEquals(2, discussionTopicCardView.getDiscussionTopicView().getReplies());
+        assertEquals(1L, discussionTopicCardView.getUserProfileCardView().getUserId());
+        assertEquals("priyanka11", discussionTopicCardView.getUserProfileCardView().getUsername());
+    }
+
+    /*
+    Find Discussion page by discussion topic id
+     */
+    @Test
+    void testFindDiscussionPageViewById() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> httpEntity = new HttpEntity<>(null, headers);
+        ResponseEntity<DiscussionPageView> responseEntity = restTemplate.exchange(getfindDiscussionPageViewByIdUri() + "/1", HttpMethod.GET, httpEntity, DiscussionPageView.class);
+        DiscussionPageView discussionPageView = responseEntity.getBody();
+        assertEquals(2, discussionPageView.getDiscussionReplyCardViewList().size());
+        DiscussionReplyCardView discussionReplyCardView = discussionPageView.getDiscussionReplyCardViewList().get(0);
+        assertEquals(1L, discussionReplyCardView.getDiscussionReplyView().getReplyId());
+        assertEquals(1L, discussionReplyCardView.getDiscussionReplyView().getDiscussionTopicId());
+        assertEquals("Yes, Loreal is better than Lakme", discussionReplyCardView.getDiscussionReplyView().getReply());
+        assertEquals(3L, discussionReplyCardView.getDiscussionReplyView().getUserId());
+        assertNotNull(discussionReplyCardView.getDiscussionReplyView().getDatePosted());
+        assertEquals(2, discussionReplyCardView.getDiscussionReplyView().getLikes());
+        assertEquals(3L, discussionReplyCardView.getUserProfileCardView().getUserId());
+        assertEquals("sonam31", discussionReplyCardView.getUserProfileCardView().getUsername());
+    }
+
+    private String getfindDiscussionTopicCardViewByIdUri() {
+        return "/" + restUriVersion + "/discussion/view/topic/id";
+    }
+
+    private String getfindDiscussionPageViewByIdUri() {
+        return "/" + restUriVersion + "/discussion/view/page/id";
+    }
+}

--- a/src/main/java/com/hexlindia/drool/common/view/UserProfileCardView.java
+++ b/src/main/java/com/hexlindia/drool/common/view/UserProfileCardView.java
@@ -1,0 +1,20 @@
+package com.hexlindia.drool.common.view;
+
+public class UserProfileCardView {
+
+    private Long userId;
+    private String username;
+
+    public UserProfileCardView(Long userId, String username) {
+        this.userId = userId;
+        this.username = username;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+}

--- a/src/main/java/com/hexlindia/drool/discussion/business/api/usecase/DiscussionView.java
+++ b/src/main/java/com/hexlindia/drool/discussion/business/api/usecase/DiscussionView.java
@@ -1,0 +1,11 @@
+package com.hexlindia.drool.discussion.business.api.usecase;
+
+import com.hexlindia.drool.discussion.view.DiscussionPageView;
+import com.hexlindia.drool.discussion.view.DiscussionTopicCardView;
+
+public interface DiscussionView {
+
+    DiscussionTopicCardView getDicussionTopicCardView(Long discussionTopicId);
+
+    DiscussionPageView getDiscussionPageView(Long discussionTopicId);
+}

--- a/src/main/java/com/hexlindia/drool/discussion/business/impl/usecase/DiscussionReplyImpl.java
+++ b/src/main/java/com/hexlindia/drool/discussion/business/impl/usecase/DiscussionReplyImpl.java
@@ -7,7 +7,7 @@ import com.hexlindia.drool.discussion.business.api.usecase.DiscussionReplyUserLi
 import com.hexlindia.drool.discussion.business.api.usecase.DiscussionTopic;
 import com.hexlindia.drool.discussion.data.entity.DiscussionReplyEntity;
 import com.hexlindia.drool.discussion.data.entity.DiscussionReplyUserLikeId;
-import com.hexlindia.drool.discussion.data.repository.DiscussionReplyRepository;
+import com.hexlindia.drool.discussion.data.repository.api.DiscussionReplyRepository;
 import com.hexlindia.drool.discussion.exception.DiscussionReplyNotFoundException;
 import com.hexlindia.drool.discussion.to.DiscussionReplyTo;
 import com.hexlindia.drool.discussion.to.mapper.DiscussionReplyMapper;

--- a/src/main/java/com/hexlindia/drool/discussion/business/impl/usecase/DiscussionReplyUserLikeImpl.java
+++ b/src/main/java/com/hexlindia/drool/discussion/business/impl/usecase/DiscussionReplyUserLikeImpl.java
@@ -3,7 +3,7 @@ package com.hexlindia.drool.discussion.business.impl.usecase;
 import com.hexlindia.drool.discussion.business.api.usecase.DiscussionReplyUserLike;
 import com.hexlindia.drool.discussion.data.entity.DiscussionReplyUserLikeEntity;
 import com.hexlindia.drool.discussion.data.entity.DiscussionReplyUserLikeId;
-import com.hexlindia.drool.discussion.data.repository.DiscussionReplyUserLikeRepository;
+import com.hexlindia.drool.discussion.data.repository.api.DiscussionReplyUserLikeRepository;
 import com.hexlindia.drool.discussion.exception.DiscussionReplyUserLikeNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/hexlindia/drool/discussion/business/impl/usecase/DiscussionTopicImpl.java
+++ b/src/main/java/com/hexlindia/drool/discussion/business/impl/usecase/DiscussionTopicImpl.java
@@ -7,7 +7,7 @@ import com.hexlindia.drool.discussion.business.api.usecase.DiscussionTopicUserLi
 import com.hexlindia.drool.discussion.data.entity.DiscussionReplyEntity;
 import com.hexlindia.drool.discussion.data.entity.DiscussionTopicEntity;
 import com.hexlindia.drool.discussion.data.entity.DiscussionTopicUserLikeId;
-import com.hexlindia.drool.discussion.data.repository.DiscussionTopicRepository;
+import com.hexlindia.drool.discussion.data.repository.api.DiscussionTopicRepository;
 import com.hexlindia.drool.discussion.exception.DiscussionTopicNotFoundException;
 import com.hexlindia.drool.discussion.to.DiscussionTopicTo;
 import com.hexlindia.drool.discussion.to.mapper.DiscussionTopicMapper;

--- a/src/main/java/com/hexlindia/drool/discussion/business/impl/usecase/DiscussionTopicUserLikeImpl.java
+++ b/src/main/java/com/hexlindia/drool/discussion/business/impl/usecase/DiscussionTopicUserLikeImpl.java
@@ -3,7 +3,7 @@ package com.hexlindia.drool.discussion.business.impl.usecase;
 import com.hexlindia.drool.discussion.business.api.usecase.DiscussionTopicUserLike;
 import com.hexlindia.drool.discussion.data.entity.DiscussionTopicUserLikeEntity;
 import com.hexlindia.drool.discussion.data.entity.DiscussionTopicUserLikeId;
-import com.hexlindia.drool.discussion.data.repository.DiscussionTopicUserLikeRepository;
+import com.hexlindia.drool.discussion.data.repository.api.DiscussionTopicUserLikeRepository;
 import com.hexlindia.drool.discussion.exception.DiscussionTopicUserLikeNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/hexlindia/drool/discussion/business/impl/usecase/DiscussionViewImpl.java
+++ b/src/main/java/com/hexlindia/drool/discussion/business/impl/usecase/DiscussionViewImpl.java
@@ -1,0 +1,27 @@
+package com.hexlindia.drool.discussion.business.impl.usecase;
+
+import com.hexlindia.drool.discussion.business.api.usecase.DiscussionView;
+import com.hexlindia.drool.discussion.data.repository.api.DiscussionViewRepository;
+import com.hexlindia.drool.discussion.view.DiscussionPageView;
+import com.hexlindia.drool.discussion.view.DiscussionTopicCardView;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DiscussionViewImpl implements DiscussionView {
+
+    private final DiscussionViewRepository discussionViewRepository;
+
+    public DiscussionViewImpl(DiscussionViewRepository discussionViewRepository) {
+        this.discussionViewRepository = discussionViewRepository;
+    }
+
+    @Override
+    public DiscussionTopicCardView getDicussionTopicCardView(Long discussionTopicId) {
+        return discussionViewRepository.getDiscussionTopicCardView(discussionTopicId);
+    }
+
+    @Override
+    public DiscussionPageView getDiscussionPageView(Long discussionTopicId) {
+        return new DiscussionPageView(discussionViewRepository.getDiscussionTopicCardView(discussionTopicId), discussionViewRepository.getDicussionReplyCardViews(discussionTopicId));
+    }
+}

--- a/src/main/java/com/hexlindia/drool/discussion/data/repository/api/DiscussionReplyRepository.java
+++ b/src/main/java/com/hexlindia/drool/discussion/data/repository/api/DiscussionReplyRepository.java
@@ -1,4 +1,4 @@
-package com.hexlindia.drool.discussion.data.repository;
+package com.hexlindia.drool.discussion.data.repository.api;
 
 import com.hexlindia.drool.discussion.data.entity.DiscussionReplyEntity;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/hexlindia/drool/discussion/data/repository/api/DiscussionReplyUserLikeRepository.java
+++ b/src/main/java/com/hexlindia/drool/discussion/data/repository/api/DiscussionReplyUserLikeRepository.java
@@ -1,4 +1,4 @@
-package com.hexlindia.drool.discussion.data.repository;
+package com.hexlindia.drool.discussion.data.repository.api;
 
 import com.hexlindia.drool.discussion.data.entity.DiscussionReplyUserLikeEntity;
 import com.hexlindia.drool.discussion.data.entity.DiscussionReplyUserLikeId;

--- a/src/main/java/com/hexlindia/drool/discussion/data/repository/api/DiscussionTopicRepository.java
+++ b/src/main/java/com/hexlindia/drool/discussion/data/repository/api/DiscussionTopicRepository.java
@@ -1,7 +1,8 @@
-package com.hexlindia.drool.discussion.data.repository;
+package com.hexlindia.drool.discussion.data.repository.api;
 
 import com.hexlindia.drool.discussion.data.entity.DiscussionTopicEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DiscussionTopicRepository extends JpaRepository<DiscussionTopicEntity, Long> {
+
 }

--- a/src/main/java/com/hexlindia/drool/discussion/data/repository/api/DiscussionTopicUserLikeRepository.java
+++ b/src/main/java/com/hexlindia/drool/discussion/data/repository/api/DiscussionTopicUserLikeRepository.java
@@ -1,4 +1,4 @@
-package com.hexlindia.drool.discussion.data.repository;
+package com.hexlindia.drool.discussion.data.repository.api;
 
 import com.hexlindia.drool.discussion.data.entity.DiscussionTopicUserLikeEntity;
 import com.hexlindia.drool.discussion.data.entity.DiscussionTopicUserLikeId;

--- a/src/main/java/com/hexlindia/drool/discussion/data/repository/api/DiscussionViewRepository.java
+++ b/src/main/java/com/hexlindia/drool/discussion/data/repository/api/DiscussionViewRepository.java
@@ -1,0 +1,13 @@
+package com.hexlindia.drool.discussion.data.repository.api;
+
+import com.hexlindia.drool.discussion.view.DiscussionReplyCardView;
+import com.hexlindia.drool.discussion.view.DiscussionTopicCardView;
+
+import java.util.List;
+
+public interface DiscussionViewRepository {
+
+    DiscussionTopicCardView getDiscussionTopicCardView(Long discussionTopicId);
+
+    List<DiscussionReplyCardView> getDicussionReplyCardViews(Long discussionTopicId);
+}

--- a/src/main/java/com/hexlindia/drool/discussion/data/repository/impl/DiscussionViewRepositoryImpl.java
+++ b/src/main/java/com/hexlindia/drool/discussion/data/repository/impl/DiscussionViewRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.hexlindia.drool.discussion.data.repository.impl;
+
+import com.hexlindia.drool.discussion.data.repository.api.DiscussionViewRepository;
+import com.hexlindia.drool.discussion.view.DiscussionReplyCardView;
+import com.hexlindia.drool.discussion.view.DiscussionTopicCardView;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import java.util.List;
+
+@Repository
+public class DiscussionViewRepositoryImpl implements DiscussionViewRepository {
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Override
+    public DiscussionTopicCardView getDiscussionTopicCardView(Long discussionTopicId) {
+        String queryString = "Select * from discussion_topic_card_view where topicId = :discussionTopicId";
+        Query query = entityManager.createNativeQuery(queryString, "discussionTopicCardView");
+        query.setParameter("discussionTopicId", discussionTopicId);
+        return (DiscussionTopicCardView) query.getSingleResult();
+    }
+
+    @Override
+    public List<DiscussionReplyCardView> getDicussionReplyCardViews(Long discussionTopicId) {
+        String queryString = "Select * from discussion_reply_card_view where discussionTopicId = :discussionTopicId";
+        Query query = entityManager.createNativeQuery(queryString, "discussionReplyCardView");
+        query.setParameter("discussionTopicId", discussionTopicId);
+        return query.getResultList();
+    }
+}

--- a/src/main/java/com/hexlindia/drool/discussion/services/api/rest/DiscussionViewRestService.java
+++ b/src/main/java/com/hexlindia/drool/discussion/services/api/rest/DiscussionViewRestService.java
@@ -1,0 +1,19 @@
+package com.hexlindia.drool.discussion.services.api.rest;
+
+import com.hexlindia.drool.discussion.view.DiscussionPageView;
+import com.hexlindia.drool.discussion.view.DiscussionTopicCardView;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/${rest.uri.version}/discussion/view")
+public interface DiscussionViewRestService {
+
+    @GetMapping(value = "/topic/id/{id}")
+    ResponseEntity<DiscussionTopicCardView> findDiscussionTopicCardViewById(@PathVariable("id") Long id);
+
+    @GetMapping(value = "/page/id/{id}")
+    ResponseEntity<DiscussionPageView> findDiscussionPageViewById(@PathVariable("id") Long id);
+
+}

--- a/src/main/java/com/hexlindia/drool/discussion/services/iml/rest/DiscussionViewRestServiceImpl.java
+++ b/src/main/java/com/hexlindia/drool/discussion/services/iml/rest/DiscussionViewRestServiceImpl.java
@@ -1,0 +1,28 @@
+package com.hexlindia.drool.discussion.services.iml.rest;
+
+import com.hexlindia.drool.discussion.business.api.usecase.DiscussionView;
+import com.hexlindia.drool.discussion.services.api.rest.DiscussionViewRestService;
+import com.hexlindia.drool.discussion.view.DiscussionPageView;
+import com.hexlindia.drool.discussion.view.DiscussionTopicCardView;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class DiscussionViewRestServiceImpl implements DiscussionViewRestService {
+
+    private final DiscussionView discussionView;
+
+    public DiscussionViewRestServiceImpl(DiscussionView discussionView) {
+        this.discussionView = discussionView;
+    }
+
+    @Override
+    public ResponseEntity<DiscussionTopicCardView> findDiscussionTopicCardViewById(Long id) {
+        return ResponseEntity.ok(this.discussionView.getDicussionTopicCardView(id));
+    }
+
+    @Override
+    public ResponseEntity<DiscussionPageView> findDiscussionPageViewById(Long id) {
+        return ResponseEntity.ok(this.discussionView.getDiscussionPageView(id));
+    }
+}

--- a/src/main/java/com/hexlindia/drool/discussion/services/iml/rest/advice/DiscussionTopicControllerAdvice.java
+++ b/src/main/java/com/hexlindia/drool/discussion/services/iml/rest/advice/DiscussionTopicControllerAdvice.java
@@ -18,7 +18,7 @@ public class DiscussionTopicControllerAdvice {
     @ResponseBody
     String handleMethodArgumentNotValidException(DataAccessException e) {
         log.error("DataAccessException is thrown with following message: {}" + e.getMessage());
-        return "Not able to create/update at this time. Try again in some time";
+        return "Not able to perform action at this time. Try again in some time";
     }
 
     @ResponseStatus(HttpStatus.NOT_FOUND)

--- a/src/main/java/com/hexlindia/drool/discussion/view/DiscussionPageView.java
+++ b/src/main/java/com/hexlindia/drool/discussion/view/DiscussionPageView.java
@@ -1,0 +1,22 @@
+package com.hexlindia.drool.discussion.view;
+
+import java.util.List;
+
+public class DiscussionPageView {
+
+    private final DiscussionTopicCardView discussionTopicCardView;
+    private final List<DiscussionReplyCardView> discussionReplyCardViewList;
+
+    public DiscussionPageView(DiscussionTopicCardView discussionTopicCardView, List<DiscussionReplyCardView> discussionReplyCardViewList) {
+        this.discussionTopicCardView = discussionTopicCardView;
+        this.discussionReplyCardViewList = discussionReplyCardViewList;
+    }
+
+    public DiscussionTopicCardView getDiscussionTopicCardView() {
+        return discussionTopicCardView;
+    }
+
+    public List<DiscussionReplyCardView> getDiscussionReplyCardViewList() {
+        return discussionReplyCardViewList;
+    }
+}

--- a/src/main/java/com/hexlindia/drool/discussion/view/DiscussionReplyCardView.java
+++ b/src/main/java/com/hexlindia/drool/discussion/view/DiscussionReplyCardView.java
@@ -1,0 +1,43 @@
+package com.hexlindia.drool.discussion.view;
+
+import com.hexlindia.drool.common.view.UserProfileCardView;
+
+import javax.persistence.ColumnResult;
+import javax.persistence.ConstructorResult;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.SqlResultSetMapping;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@SqlResultSetMapping(name = "discussionReplyCardView",
+        classes = {
+                @ConstructorResult(
+                        targetClass = DiscussionReplyCardView.class,
+                        columns = {
+                                @ColumnResult(name = "replyId", type = Long.class),
+                                @ColumnResult(name = "discussionTopicId", type = Long.class),
+                                @ColumnResult(name = "reply", type = String.class),
+                                @ColumnResult(name = "userId", type = Long.class),
+                                @ColumnResult(name = "datePosted", type = LocalDateTime.class),
+                                @ColumnResult(name = "likes", type = Integer.class),
+                                @ColumnResult(name = "username", type = String.class)
+                        })
+        })
+public class DiscussionReplyCardView {
+
+    private DiscussionReplyView discussionReplyView;
+    private UserProfileCardView userProfileCardView;
+
+    public DiscussionReplyCardView(Long replyId, Long discussionTopicId, String reply, Long userId, LocalDateTime datePosted, int likes, String username) {
+        this.discussionReplyView = new DiscussionReplyView(replyId, discussionTopicId, reply, userId, datePosted, likes);
+        this.userProfileCardView = new UserProfileCardView(userId, username);
+    }
+
+    public DiscussionReplyView getDiscussionReplyView() {
+        return discussionReplyView;
+    }
+
+    public UserProfileCardView getUserProfileCardView() {
+        return userProfileCardView;
+    }
+}

--- a/src/main/java/com/hexlindia/drool/discussion/view/DiscussionReplyView.java
+++ b/src/main/java/com/hexlindia/drool/discussion/view/DiscussionReplyView.java
@@ -1,0 +1,46 @@
+package com.hexlindia.drool.discussion.view;
+
+import java.time.LocalDateTime;
+
+public class DiscussionReplyView {
+
+    private Long replyId;
+    private Long discussionTopicId;
+    private String reply;
+    private Long userId;
+    private LocalDateTime datePosted;
+    private int likes;
+
+    public DiscussionReplyView(Long replyId, Long discussionTopicId, String reply, Long userId, LocalDateTime datePosted, int likes) {
+        this.replyId = replyId;
+        this.discussionTopicId = discussionTopicId;
+        this.reply = reply;
+        this.userId = userId;
+        this.datePosted = datePosted;
+        this.likes = likes;
+    }
+
+    public Long getReplyId() {
+        return replyId;
+    }
+
+    public Long getDiscussionTopicId() {
+        return discussionTopicId;
+    }
+
+    public String getReply() {
+        return reply;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public LocalDateTime getDatePosted() {
+        return datePosted;
+    }
+
+    public int getLikes() {
+        return likes;
+    }
+}

--- a/src/main/java/com/hexlindia/drool/discussion/view/DiscussionTopicCardView.java
+++ b/src/main/java/com/hexlindia/drool/discussion/view/DiscussionTopicCardView.java
@@ -1,0 +1,45 @@
+package com.hexlindia.drool.discussion.view;
+
+import com.hexlindia.drool.common.view.UserProfileCardView;
+
+import javax.persistence.ColumnResult;
+import javax.persistence.ConstructorResult;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.SqlResultSetMapping;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@SqlResultSetMapping(name = "discussionTopicCardView",
+        classes = {
+                @ConstructorResult(
+                        targetClass = DiscussionTopicCardView.class,
+                        columns = {
+                                @ColumnResult(name = "topicId", type = Long.class),
+                                @ColumnResult(name = "topic", type = String.class),
+                                @ColumnResult(name = "userId", type = Long.class),
+                                @ColumnResult(name = "datePosted", type = LocalDateTime.class),
+                                @ColumnResult(name = "dateLastActive", type = LocalDateTime.class),
+                                @ColumnResult(name = "views", type = Integer.class),
+                                @ColumnResult(name = "likes", type = Integer.class),
+                                @ColumnResult(name = "replies", type = Integer.class),
+                                @ColumnResult(name = "username", type = String.class)
+                        })
+        })
+public class DiscussionTopicCardView {
+
+    private DiscussionTopicView discussionTopicView;
+    private UserProfileCardView userProfileCardView;
+
+    public DiscussionTopicCardView(Long topicId, String topic, Long userId, LocalDateTime datePosted, LocalDateTime dateLastActive, int views, int likes, int replies, String username) {
+        this.discussionTopicView = new DiscussionTopicView(topicId, topic, userId, datePosted, dateLastActive, views, likes, replies);
+        this.userProfileCardView = new UserProfileCardView(userId, username);
+    }
+
+    public DiscussionTopicView getDiscussionTopicView() {
+        return discussionTopicView;
+    }
+
+    public UserProfileCardView getUserProfileCardView() {
+        return userProfileCardView;
+    }
+}

--- a/src/main/java/com/hexlindia/drool/discussion/view/DiscussionTopicView.java
+++ b/src/main/java/com/hexlindia/drool/discussion/view/DiscussionTopicView.java
@@ -1,0 +1,58 @@
+package com.hexlindia.drool.discussion.view;
+
+import java.time.LocalDateTime;
+
+public class DiscussionTopicView {
+
+    private Long topicId;
+    private String topic;
+    private Long userId;
+    private LocalDateTime datePosted;
+    private LocalDateTime dateLastActive;
+    private int views;
+    private int likes;
+    private int replies;
+
+    public DiscussionTopicView(Long topicId, String topic, Long userId, LocalDateTime datePosted, LocalDateTime dateLastActive, int views, int likes, int replies) {
+        this.topicId = topicId;
+        this.topic = topic;
+        this.userId = userId;
+        this.datePosted = datePosted;
+        this.dateLastActive = dateLastActive;
+        this.views = views;
+        this.likes = likes;
+        this.replies = replies;
+    }
+
+    public Long getTopicId() {
+        return topicId;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public LocalDateTime getDatePosted() {
+        return datePosted;
+    }
+
+    public LocalDateTime getDateLastActive() {
+        return dateLastActive;
+    }
+
+    public int getViews() {
+        return views;
+    }
+
+    public int getLikes() {
+        return likes;
+    }
+
+    public int getReplies() {
+        return replies;
+    }
+}

--- a/src/main/java/com/hexlindia/drool/user/config/WebSecurityConfig.java
+++ b/src/main/java/com/hexlindia/drool/user/config/WebSecurityConfig.java
@@ -31,7 +31,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final UserDetailsService jwtUserDetailsService;
     private final JwtValidationFilter jwtValidationFilter;
-    private final String[] unsecuredEndpoints = {"/account/authenticate", "/account/register", "/account/find/email/*", "/profile/find/username/*"};
+    private final String[] unsecuredEndpoints = {"/user/account/authenticate", "/user/account/register", "/user/account/find/email/*", "/user/profile/find/username/*", "/discussion/view/**"};
 
     @Autowired
     public WebSecurityConfig(@Value("${rest.uri.version}") final String restUriVersion, JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint, UserDetailsService jwtUserDetailsService, JwtValidationFilter jwtValidationFilter) {
@@ -82,7 +82,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     private String[] getUnsecuredUris() {
         String[] unsecuredUris = new String[unsecuredEndpoints.length];
         for (int i = 0; i < unsecuredUris.length; i++) {
-            unsecuredUris[i] = "/" + restUriVersion + "/user" + unsecuredEndpoints[i];
+            unsecuredUris[i] = "/" + restUriVersion + unsecuredEndpoints[i];
         }
         return unsecuredUris;
     }

--- a/src/main/java/com/hexlindia/drool/user/filters/JwtValidationFilter.java
+++ b/src/main/java/com/hexlindia/drool/user/filters/JwtValidationFilter.java
@@ -42,17 +42,21 @@ public class JwtValidationFilter extends OncePerRequestFilter {
         String jwtToken = null;
         // JWT Token is in the form "Bearer token". Remove Bearer word and get
         // only the Token
-        if (requestTokenHeader != null && requestTokenHeader.startsWith("Bearer ")) {
-            jwtToken = requestTokenHeader.substring(7);
-            try {
-                username = jwtUtil.getUsernameFromToken(jwtToken);
-            } catch (IllegalArgumentException e) {
-                log.error("Unable to get JWT Token");
-            } catch (ExpiredJwtException e) {
-                log.error("JWT Token has expired");
+        if (requestTokenHeader != null) {
+            if (requestTokenHeader.startsWith("Bearer ")) {
+                jwtToken = requestTokenHeader.substring(7);
+                try {
+                    username = jwtUtil.getUsernameFromToken(jwtToken);
+                } catch (IllegalArgumentException e) {
+                    log.error("Unable to get JWT Token");
+                } catch (ExpiredJwtException e) {
+                    log.error("JWT Token has expired");
+                }
+            } else {
+                log.info("JWT Token does not begin with Bearer String");
             }
         } else {
-            log.error("JWT Token does not begin with Bearer String");
+            log.info("Authorization header not found");
         }
 
         // Once we get the token validate it.

--- a/src/main/resources/db/postgresql/common/V1__table_creation.sql
+++ b/src/main/resources/db/postgresql/common/V1__table_creation.sql
@@ -68,3 +68,34 @@ CREATE TABLE POST_TYPE
     post_type    VARCHAR(50)
 );
 
+CREATE OR REPLACE VIEW user_profile_card_view AS
+SELECT up.user_account_id AS userId,
+       up.username        AS username
+FROM user_profile up;
+
+CREATE OR REPLACE VIEW discussion_topic_card_view AS
+SELECT topic.id               AS topicId,
+       topic.topic            AS topic,
+       topic.user_id          AS userId,
+       topic.date_posted      AS datePosted,
+       topic.date_last_active AS dateLastActive,
+       topic.views            AS views,
+       topic.likes            AS likes,
+       topic.replies          AS replies,
+       upcard.username        AS username
+FROM discussion_topic topic
+         INNER JOIN user_profile_card_view upcard ON topic.user_id = upcard.userId
+where topic.active;
+
+CREATE OR REPLACE VIEW discussion_reply_card_view AS
+SELECT reply.id                  AS replyId,
+       reply.discussion_topic_id AS discussionTopicId,
+       reply.reply               AS reply,
+       reply.user_id             AS userId,
+       reply.date_posted         AS datePosted,
+       reply.likes               AS likes,
+       upcard.username           AS username
+FROM discussion_reply reply
+         INNER JOIN user_profile_card_view upcard ON reply.user_id = upcard.userId
+where reply.active;
+

--- a/src/main/resources/db/postgresql/test/V2__data_insertion.sql
+++ b/src/main/resources/db/postgresql/test/V2__data_insertion.sql
@@ -14,18 +14,18 @@ insert into user_profile(user_account_id, username, mobile, city, gender)
 values (3, 'sonam31', 7654321098, 'Jaipur', 'F');
 
 insert into discussion_topic(topic, user_id, date_posted, date_last_active, views, likes, replies)
-values ('Are Loreal lip colors better than Lakme or is it the other way around', 5, now(), now(), 15, 12, 3);
+values ('Are Loreal lip colors better than Lakme or is it the other way around', 1, now(), now(), 15, 12, 3);
 
 insert into discussion_reply(discussion_topic_id, reply, user_id, date_posted, likes)
-values (1, 'Yes, Loreal is better than Lakme', 4, now(), 2);
+values (1, 'Yes, Loreal is better than Lakme', 3, now(), 2);
 
 insert into discussion_reply(discussion_topic_id, reply, user_id, active, date_posted, likes)
-values (1, 'No, I dont think Loreal products are any better than Lakme. It is just the hype', 8, false, now(), 4);
+values (1, 'No, I dont think Loreal products are any better than Lakme. It is just the hype', 2, false, now(), 4);
 
 insert into discussion_reply(discussion_topic_id, reply, user_id, date_posted, likes)
 values (1,
         'It depends on the products you are looking at. For lip colors loreal is better. But then for other things Lakme is better',
-        2, now(), 3);
+        1, now(), 3);
 
 insert into POST_TYPE(post_type_id, post_type)
 values (1, 'Topic');

--- a/src/test/java/com/hexlindia/drool/discussion/business/impl/usecase/DiscussionReplyImplTest.java
+++ b/src/test/java/com/hexlindia/drool/discussion/business/impl/usecase/DiscussionReplyImplTest.java
@@ -6,7 +6,7 @@ import com.hexlindia.drool.discussion.business.api.usecase.DiscussionTopic;
 import com.hexlindia.drool.discussion.data.entity.DiscussionReplyEntity;
 import com.hexlindia.drool.discussion.data.entity.DiscussionReplyUserLikeId;
 import com.hexlindia.drool.discussion.data.entity.DiscussionTopicEntity;
-import com.hexlindia.drool.discussion.data.repository.DiscussionReplyRepository;
+import com.hexlindia.drool.discussion.data.repository.api.DiscussionReplyRepository;
 import com.hexlindia.drool.discussion.exception.DiscussionReplyNotFoundException;
 import com.hexlindia.drool.discussion.to.DiscussionReplyTo;
 import com.hexlindia.drool.discussion.to.mapper.DiscussionReplyMapper;

--- a/src/test/java/com/hexlindia/drool/discussion/business/impl/usecase/DiscussionReplyUserLikeImplTest.java
+++ b/src/test/java/com/hexlindia/drool/discussion/business/impl/usecase/DiscussionReplyUserLikeImplTest.java
@@ -2,7 +2,7 @@ package com.hexlindia.drool.discussion.business.impl.usecase;
 
 import com.hexlindia.drool.discussion.data.entity.DiscussionReplyUserLikeEntity;
 import com.hexlindia.drool.discussion.data.entity.DiscussionReplyUserLikeId;
-import com.hexlindia.drool.discussion.data.repository.DiscussionReplyUserLikeRepository;
+import com.hexlindia.drool.discussion.data.repository.api.DiscussionReplyUserLikeRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;

--- a/src/test/java/com/hexlindia/drool/discussion/business/impl/usecase/DiscussionTopicImplTest.java
+++ b/src/test/java/com/hexlindia/drool/discussion/business/impl/usecase/DiscussionTopicImplTest.java
@@ -4,7 +4,7 @@ import com.hexlindia.drool.common.to.ActivityTo;
 import com.hexlindia.drool.discussion.business.api.usecase.DiscussionTopicUserLike;
 import com.hexlindia.drool.discussion.data.entity.DiscussionTopicEntity;
 import com.hexlindia.drool.discussion.data.entity.DiscussionTopicUserLikeId;
-import com.hexlindia.drool.discussion.data.repository.DiscussionTopicRepository;
+import com.hexlindia.drool.discussion.data.repository.api.DiscussionTopicRepository;
 import com.hexlindia.drool.discussion.exception.DiscussionTopicNotFoundException;
 import com.hexlindia.drool.discussion.to.DiscussionTopicTo;
 import com.hexlindia.drool.discussion.to.mapper.DiscussionTopicMapper;

--- a/src/test/java/com/hexlindia/drool/discussion/business/impl/usecase/DiscussionTopicUserLikeImplTest.java
+++ b/src/test/java/com/hexlindia/drool/discussion/business/impl/usecase/DiscussionTopicUserLikeImplTest.java
@@ -2,7 +2,7 @@ package com.hexlindia.drool.discussion.business.impl.usecase;
 
 import com.hexlindia.drool.discussion.data.entity.DiscussionTopicUserLikeEntity;
 import com.hexlindia.drool.discussion.data.entity.DiscussionTopicUserLikeId;
-import com.hexlindia.drool.discussion.data.repository.DiscussionTopicUserLikeRepository;
+import com.hexlindia.drool.discussion.data.repository.api.DiscussionTopicUserLikeRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;

--- a/src/test/java/com/hexlindia/drool/discussion/data/repository/DiscussionReplyRepositoryTest.java
+++ b/src/test/java/com/hexlindia/drool/discussion/data/repository/DiscussionReplyRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.hexlindia.drool.discussion.data.repository;
 
 import com.hexlindia.drool.discussion.data.entity.DiscussionReplyEntity;
+import com.hexlindia.drool.discussion.data.repository.api.DiscussionReplyRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -19,14 +20,14 @@ class DiscussionReplyRepositoryTest {
     void testFind() {
         DiscussionReplyEntity discussionReplyEntityRetrieved = this.discussionReplyRepository.findById(1L).get();
         assertEquals("Yes, Loreal is better than Lakme", discussionReplyEntityRetrieved.getReply());
-        assertEquals(4L, discussionReplyEntityRetrieved.getUserId());
+        assertEquals(3L, discussionReplyEntityRetrieved.getUserId());
     }
 
     @Test
     void testSave() {
         discussionReplyRepository.save(new DiscussionReplyEntity("No, it is not better", 3L));
 
-        Optional<DiscussionReplyEntity> discussionReplyEntityRetrievedOptional = this.discussionReplyRepository.findById(3L);
+        Optional<DiscussionReplyEntity> discussionReplyEntityRetrievedOptional = this.discussionReplyRepository.findById(4L);
         assertTrue(discussionReplyEntityRetrievedOptional.isPresent());
         DiscussionReplyEntity discussionReplyEntityRetrieved = discussionReplyEntityRetrievedOptional.get();
         assertEquals("No, it is not better", discussionReplyEntityRetrieved.getReply());

--- a/src/test/java/com/hexlindia/drool/discussion/data/repository/DiscussionReplyUserLikeRepositoryTest.java
+++ b/src/test/java/com/hexlindia/drool/discussion/data/repository/DiscussionReplyUserLikeRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.hexlindia.drool.discussion.data.repository;
 
 import com.hexlindia.drool.discussion.data.entity.DiscussionReplyUserLikeId;
+import com.hexlindia.drool.discussion.data.repository.api.DiscussionReplyUserLikeRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;

--- a/src/test/java/com/hexlindia/drool/discussion/data/repository/DiscussionTopicRepositoryTest.java
+++ b/src/test/java/com/hexlindia/drool/discussion/data/repository/DiscussionTopicRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.hexlindia.drool.discussion.data.repository;
 
 import com.hexlindia.drool.discussion.data.entity.DiscussionTopicEntity;
+import com.hexlindia.drool.discussion.data.repository.api.DiscussionTopicRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -20,8 +21,8 @@ class DiscussionTopicRepositoryTest {
     void testFind() {
         DiscussionTopicEntity discussionTopicEntityRetrieved = this.discussionTopicRepository.findById(1L).get();
         assertEquals("Are Loreal lip colors better than Lakme or is it the other way around", discussionTopicEntityRetrieved.getTopic());
-        assertEquals(5L, discussionTopicEntityRetrieved.getUserId());
-        assertEquals(1, discussionTopicEntityRetrieved.getDiscussionReplyEntityList().size());
+        assertEquals(1L, discussionTopicEntityRetrieved.getUserId());
+        assertEquals(2, discussionTopicEntityRetrieved.getDiscussionReplyEntityList().size());
     }
 
     @Test

--- a/src/test/java/com/hexlindia/drool/discussion/data/repository/DiscussionTopicUserLikeRepositoryTest.java
+++ b/src/test/java/com/hexlindia/drool/discussion/data/repository/DiscussionTopicUserLikeRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.hexlindia.drool.discussion.data.repository;
 
 import com.hexlindia.drool.discussion.data.entity.DiscussionTopicUserLikeId;
+import com.hexlindia.drool.discussion.data.repository.api.DiscussionTopicUserLikeRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;

--- a/src/test/java/com/hexlindia/drool/discussion/data/repository/impl/DiscussionViewRepositoryImplTest.java
+++ b/src/test/java/com/hexlindia/drool/discussion/data/repository/impl/DiscussionViewRepositoryImplTest.java
@@ -1,0 +1,51 @@
+package com.hexlindia.drool.discussion.data.repository.impl;
+
+import com.hexlindia.drool.discussion.data.repository.api.DiscussionViewRepository;
+import com.hexlindia.drool.discussion.view.DiscussionReplyCardView;
+import com.hexlindia.drool.discussion.view.DiscussionTopicCardView;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class DiscussionViewRepositoryImplTest {
+
+    @Autowired
+    DiscussionViewRepository discussionViewRepository;
+
+    @Test
+    void getDicussionReplyCardViews() {
+        List<DiscussionReplyCardView> discussionReplyCardViewList = discussionViewRepository.getDicussionReplyCardViews(1L);
+        assertNotNull(discussionReplyCardViewList);
+        assertEquals(2, discussionReplyCardViewList.size());
+        DiscussionReplyCardView discussionReplyCardView = discussionReplyCardViewList.get(0);
+        assertEquals(1L, discussionReplyCardView.getDiscussionReplyView().getReplyId());
+        assertEquals(1L, discussionReplyCardView.getDiscussionReplyView().getDiscussionTopicId());
+        assertNotNull(discussionReplyCardView.getDiscussionReplyView().getReply());
+        assertEquals(3L, discussionReplyCardView.getDiscussionReplyView().getUserId());
+        assertNotNull(discussionReplyCardView.getDiscussionReplyView().getDatePosted());
+        assertEquals(2, discussionReplyCardView.getDiscussionReplyView().getLikes());
+        assertEquals(3L, discussionReplyCardView.getUserProfileCardView().getUserId());
+        assertEquals("sonam31", discussionReplyCardView.getUserProfileCardView().getUsername());
+    }
+
+    @Test
+    void getDicussionTopicCardView() {
+        DiscussionTopicCardView discussionTopicCardView = discussionViewRepository.getDiscussionTopicCardView(1L);
+        assertNotNull(discussionTopicCardView);
+        assertEquals(1L, discussionTopicCardView.getDiscussionTopicView().getTopicId());
+        assertNotNull(discussionTopicCardView.getDiscussionTopicView().getTopic());
+        assertEquals(1L, discussionTopicCardView.getDiscussionTopicView().getUserId());
+        assertNotNull(discussionTopicCardView.getDiscussionTopicView().getDatePosted());
+        assertNotNull(discussionTopicCardView.getDiscussionTopicView().getDateLastActive());
+        assertTrue(discussionTopicCardView.getDiscussionTopicView().getViews() >= 15);
+        assertEquals(12, discussionTopicCardView.getDiscussionTopicView().getLikes());
+        assertEquals(2, discussionTopicCardView.getDiscussionTopicView().getReplies());
+        assertEquals(1L, discussionTopicCardView.getUserProfileCardView().getUserId());
+        assertEquals("priyanka11", discussionTopicCardView.getUserProfileCardView().getUsername());
+    }
+}

--- a/src/test/java/com/hexlindia/drool/discussion/services/iml/rest/DiscussionReplyRestServiceImplTest.java
+++ b/src/test/java/com/hexlindia/drool/discussion/services/iml/rest/DiscussionReplyRestServiceImplTest.java
@@ -136,7 +136,7 @@ class DiscussionReplyRestServiceImplTest {
                 .andExpect(status().is5xxServerError())
                 .andReturn();
 
-        assertEquals("Not able to create/update at this time. Try again in some time", mvcResult.getResponse().getContentAsString());
+        assertEquals("Not able to perform action at this time. Try again in some time", mvcResult.getResponse().getContentAsString());
     }
 
     @Test

--- a/src/test/java/com/hexlindia/drool/discussion/services/iml/rest/DiscussionTopicRestServiceImplTest.java
+++ b/src/test/java/com/hexlindia/drool/discussion/services/iml/rest/DiscussionTopicRestServiceImplTest.java
@@ -121,7 +121,7 @@ class DiscussionTopicRestServiceImplTest {
                 .andExpect(status().is5xxServerError())
                 .andReturn();
 
-        assertEquals("Not able to create/update at this time. Try again in some time", mvcResult.getResponse().getContentAsString());
+        assertEquals("Not able to perform action at this time. Try again in some time", mvcResult.getResponse().getContentAsString());
     }
 
     @Test

--- a/src/test/java/com/hexlindia/drool/discussion/services/iml/rest/DiscussionViewRestServiceImplTest.java
+++ b/src/test/java/com/hexlindia/drool/discussion/services/iml/rest/DiscussionViewRestServiceImplTest.java
@@ -1,0 +1,91 @@
+package com.hexlindia.drool.discussion.services.iml.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hexlindia.drool.discussion.business.api.usecase.DiscussionView;
+import com.hexlindia.drool.user.filters.JwtValidationFilter;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = DiscussionViewRestServiceImpl.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {WebSecurityConfigurer.class, JwtValidationFilter.class}),
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class})
+class DiscussionViewRestServiceImplTest {
+
+    @Value("${rest.uri.version}")
+    String restUriVersion;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    DiscussionView discussionView;
+
+    @Test
+    public void findDiscussionTopicCardViewById_HttpMethodNotAllowedError() throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders.put(getfindDiscussionTopicCardViewByIdUri() + "/1"))
+                .andExpect(status().isMethodNotAllowed());
+    }
+
+    @Test
+    public void findDiscussionTopicCardViewById_ParametersMissing() throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders.post(getfindDiscussionTopicCardViewByIdUri() + "/"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void findDiscussionTopicCardViewById_ParametersPassedToBusinessLayer() throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders.get(getfindDiscussionTopicCardViewByIdUri() + "/101"));
+
+        ArgumentCaptor<Long> idArgumentCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(this.discussionView, times(1)).getDicussionTopicCardView(idArgumentCaptor.capture());
+        assertEquals(101L, idArgumentCaptor.getValue());
+    }
+
+    @Test
+    public void findDiscussionPageViewById_HttpMethodNotAllowedError() throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders.put(getfindDiscussionPageViewByIdUri() + "/1"))
+                .andExpect(status().isMethodNotAllowed());
+    }
+
+    @Test
+    public void findDiscussionPageViewById_ParametersMissing() throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders.post(getfindDiscussionPageViewByIdUri() + "/"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void findDiscussionPageViewById_ParametersPassedToBusinessLayer() throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders.get(getfindDiscussionPageViewByIdUri() + "/101"));
+
+        ArgumentCaptor<Long> idArgumentCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(this.discussionView, times(1)).getDiscussionPageView(idArgumentCaptor.capture());
+        assertEquals(101L, idArgumentCaptor.getValue());
+    }
+
+    private String getfindDiscussionTopicCardViewByIdUri() {
+        return "/" + restUriVersion + "/discussion/view/topic/id";
+    }
+
+    private String getfindDiscussionPageViewByIdUri() {
+        return "/" + restUriVersion + "/discussion/view/page/id";
+    }
+}

--- a/src/test/java/com/hexlindia/drool/user/data/repository/DiscussionTopicUserLikeRepositoryTest.java
+++ b/src/test/java/com/hexlindia/drool/user/data/repository/DiscussionTopicUserLikeRepositoryTest.java
@@ -2,7 +2,7 @@ package com.hexlindia.drool.user.data.repository;
 
 import com.hexlindia.drool.discussion.data.entity.DiscussionTopicUserLikeEntity;
 import com.hexlindia.drool.discussion.data.entity.DiscussionTopicUserLikeId;
-import com.hexlindia.drool.discussion.data.repository.DiscussionTopicUserLikeRepository;
+import com.hexlindia.drool.discussion.data.repository.api.DiscussionTopicUserLikeRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;

--- a/src/test/resources/db/migration/h2/V1__table_creation.sql
+++ b/src/test/resources/db/migration/h2/V1__table_creation.sql
@@ -70,3 +70,39 @@ CREATE TABLE POST_TYPE
     post_type    VARCHAR(50)
 );
 
+CREATE OR REPLACE VIEW user_profile_card_view AS
+SELECT up.user_account_id AS userId,
+       up.username        AS username
+FROM user_profile up;
+
+CREATE OR REPLACE VIEW discussion_topic_card_view AS
+SELECT topic.id               AS topicId,
+       topic.topic            AS topic,
+       topic.user_id          AS userId,
+       topic.date_posted      AS datePosted,
+       topic.date_last_active AS dateLastActive,
+       topic.views            AS views,
+       topic.likes            AS likes,
+       topic.replies          AS replies,
+       upcard.username        AS username
+FROM discussion_topic topic
+         INNER JOIN user_profile_card_view upcard ON topic.user_id = upcard.userId
+where topic.active = true;
+
+CREATE OR REPLACE VIEW discussion_reply_card_view AS
+SELECT reply.id                  AS replyId,
+       reply.discussion_topic_id AS discussionTopicId,
+       reply.reply               AS reply,
+       reply.user_id             AS userId,
+       reply.date_posted         AS datePosted,
+       reply.likes               AS likes,
+       upcard.username           AS username
+FROM discussion_reply reply
+         INNER JOIN user_profile_card_view upcard ON reply.user_id = upcard.userId
+where reply.active = true;
+
+
+
+
+
+

--- a/src/test/resources/db/migration/h2/V2__data_insertion.sql
+++ b/src/test/resources/db/migration/h2/V2__data_insertion.sql
@@ -14,13 +14,16 @@ insert into user_profile(user_account_id, username, mobile, city, gender)
 values (3, 'sonam31', 7654321098, 'Jaipur', 'F');
 
 insert into discussion_topic(topic, user_id, date_posted, date_last_active, views, likes, replies)
-values ('Are Loreal lip colors better than Lakme or is it the other way around', 5, now(), now(), 15, 12, 1);
+values ('Are Loreal lip colors better than Lakme or is it the other way around', 1, now(), now(), 15, 12, 2);
 
 insert into discussion_reply(discussion_topic_id, reply, user_id, date_posted, likes)
-values (1, 'Yes, Loreal is better than Lakme', 4, now(), 2);
+values (1, 'Yes, Loreal is better than Lakme', 3, now(), 2);
 
 insert into discussion_reply(discussion_topic_id, reply, user_id, active, date_posted, likes)
 values (1, 'No, Loreal is better than Lakme', 2, false, now(), 2);
+
+insert into discussion_reply(discussion_topic_id, reply, user_id, active, date_posted, likes)
+values (1, 'It is not a straight answer', 1, true, now(), 2);
 
 insert into POST_TYPE(post_type_id, post_type)
 values (1, 'Topic');


### PR DESCRIPTION
SQL VIEWS were created to join Discussion topic and Discussion reply with User profile.

These SQL VIEWS are mapped to read-only POJOs suffixed with *View. No authorization is required to access these views.